### PR TITLE
styling hotfix

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -93,11 +93,15 @@ webui-tabs {
   /* better solutions to this ? */
   [aria-selected="true"] + [data-tab]:last-child,
   [data-tab] + [aria-selected="true"]:last-child {
-    padding-left: 36px;
+    border-left: 1px solid var(--very-light-grey);
   }
 
   [data-tab]:has(+ [aria-selected="true"]:last-child) {
-    padding-left: 34px; /*prevent text shift due to border change*/
+    padding-left: 34px; /*prevent text shift due to border changes*/
+  }
+
+  [data-tab]:focus-visible {
+    z-index: 2;
   }
 
   /* style roles added by javascript */


### PR DESCRIPTION
- change style rule to change border property as this makes more sense
- pop selected tab up so that outline style applied using focus-within (keyboard select) looks better