### PR TITLE
generalise tab spacing logic for n tabs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,38 @@
 # em-code-interview
+
 Code to discuss duriing the interview. I took the tab task from the invite document and combined it with some of my own existing code, so the tabs are styled according to the supplied jpeg (see below) but with different focus / content.
 
 # to launch
+
 launch a python server
+
 ```
 python3 -m http.server 8000
 ```
-then visit 
+
+then visit
 [http://localhost:8000](http://localhost:8000/)
 
 alternatively see any of these methods:
 [https://medium.com/sweetmeat/simple-one-line-local-http-servers-8adb57d93ec3](https://medium.com/sweetmeat/simple-one-line-local-http-servers-8adb57d93ec3)
 
 # possible talking points:
+
 - are tabs bad UI for websites?
 - are web components ready?
 - where are web components in relation to frameworks?
 - what are the use cases of web components?
-- the border logic on the tabs... is there a better way?
+- the border logic on the tabs.
+  \/
+
+5 tabs, 'A' represents the active tab, numbers are border thickness
+
+| 1 A 1 | 0 - 0 | 1 - 0 | 1 - 0 | 1 - 0 | 1 - 0 |
+| ----- | ----- | ----- | ----- | ----- | ----- |
+| 1 - 0 | 1 A 1 | 0 - 0 | 1 - 0 | 1 - 0 | 1 - 0 |
+| 1 - 0 | 1 - 0 | 1 A 1 | 0 - 0 | 1 - 0 | 1 - 0 |
+| 1 - 0 | 1 - 0 | 1 - 0 | 1 A 1 | 0 - 0 | 1 - 0 |
+| 1 - 0 | 1 - 0 | 1 - 0 | 1 - 0 | 1 A 1 | 0 - 0 |
+| 1 - 0 | 1 - 0 | 1 - 0 | 1 - 0 | 1 - 0 | 1 A 1 |
 
 ![tabs](https://github.com/user-attachments/assets/804d3d2e-ba8a-4e36-8934-eaac100523b0)

--- a/index.html
+++ b/index.html
@@ -24,6 +24,8 @@
           <a href="#tab1" data-tab>BBC Radio 1</a>
           <a href="#tab2" data-tab>BBC Radio 2</a>
           <a href="#tab3" data-tab>BBC Radio 3</a>
+          <a href="#tab4" data-tab>BBC Radio 4</a>
+          <a href="#tab5" data-tab>BBC Radio 5</a>
         </div>
         <div id="tab1" data-tabpanel>
           <p>
@@ -58,6 +60,31 @@
             broadcasts classical music and opera, with jazz, world music,
             culture and the arts also featuring. The station has described
             itself as "the world's most significant commissioner of new music".
+          </p>
+        </div>
+
+        <div id="tab4" data-tabpanel>
+          <p>
+            BBC Radio 4 is a British national radio station owned and operated
+            by the BBC. The station replaced the BBC Home Service on 30
+            September 1967 and broadcasts a wide variety of spoken-word
+            programmes from the BBC's headquarters at Broadcasting House,
+            London. Since 2019, the station controller has been Mohit Bakaya. He
+            replaced Gwyneth Williams, who had been the station controller since
+            2010.
+          </p>
+        </div>
+
+        <div id="tab5" data-tabpanel>
+          <p>
+            BBC Radio 5 Live is a British national radio station owned and
+            operated by the BBC. It broadcasts mainly news, sport, discussion,
+            interviews and phone-ins, and is on air 24 hours a day. It is the
+            principal BBC radio station covering sport in the United Kingdom,
+            broadcasting virtually all major sports events staged in the UK or
+            involving British competitors. The station broadcasts from
+            MediaCityUK in Salford, England, and is a department of the BBC
+            North division.
           </p>
         </div>
       </webui-tabs>

--- a/styles.css
+++ b/styles.css
@@ -90,32 +90,26 @@ webui-tabs {
     border-right: 0;
   }
 
-
-
   /* better solutions to this ? */
-  [aria-selected="true"] + [data-tab]:last-child {
-    border-left: 0;
-    border-right: 0;
+  [data-tab] {
+    border-left: 1px solid var(--off-white);
+    border-right: 0px;
   }
 
-  [aria-selected="true"]:has(+ [aria-selected="false"]:last-child) {
-    border-left: 0;
+  [aria-selected="true"] {
+    border-left: 1px solid transparent;
     border-right: 1px solid transparent;
   }
 
-  [data-tab]:has(+ [aria-selected="true"]:last-child) {
+  [aria-selected="true"] + [data-tab] {
     border-left: 0;
-    border-right: 1px solid transparent;
-  }
-
-  [data-tab]:last-child {
     border-right: 0;
   }
 
   [aria-selected="true"]:last-child {
-    border-left: 0;
+    border-left: 1px solid transparent;
+    border-right: 0;
   }
-
 
   [data-tab]:focus-visible {
     z-index: 2;
@@ -126,7 +120,6 @@ webui-tabs {
     background-color: var(--default-background-color);
     box-shadow: 0px 3px 0px 0px var(--active-section-indicator) inset;
     border-top: 1px solid var(--active-section-indicator);
-    border-right: 0;
     margin: 0;
   }
 


### PR DESCRIPTION
the tab border previous logic didn't scale for more tabs
this PR fixes that. 
the tab logic (example of 5 tabs) is

5 tabs, 'A' represents the active tab, numbers are border thickness

| 1 A 1 | 0 - 0 | 1 - 0 | 1 - 0 | 1 - 0 | 1 - 0 |
| ----- | ----- | ----- | ----- | ----- | ----- |
| 1 - 0 | 1 A 1 | 0 - 0 | 1 - 0 | 1 - 0 | 1 - 0 |
| 1 - 0 | 1 - 0 | 1 A 1 | 0 - 0 | 1 - 0 | 1 - 0 |
| 1 - 0 | 1 - 0 | 1 - 0 | 1 A 1 | 0 - 0 | 1 - 0 |
| 1 - 0 | 1 - 0 | 1 - 0 | 1 - 0 | 1 A 1 | 0 - 0 |
| 1 - 0 | 1 - 0 | 1 - 0 | 1 - 0 | 1 - 0 | 1 A 1 |